### PR TITLE
feat: Refactor charter and video handling to utilize junction tables for improved data relationships and queries

### DIFF
--- a/prisma/migrations/20251103165919_update_public_charters_view_use_junction_table/migration.sql
+++ b/prisma/migrations/20251103165919_update_public_charters_view_use_junction_table/migration.sql
@@ -1,0 +1,219 @@
+-- Update v_public_charters view to use CharterVideo junction table instead of CaptainVideo direct FK
+-- This migration ensures the view uses the proper many-to-many relationship with ordering
+
+DROP VIEW IF EXISTS "public"."v_public_charters";
+CREATE VIEW "public"."v_public_charters" AS
+SELECT 
+    c.id,
+    -- Wrap all columns in a charter jsonb object
+    jsonb_build_object(
+        'id', c.id,
+        'name', c."name",
+        'charterType', c."charterType",
+        'state', c.state,
+        'district', c.city,
+        'startingPoint', c."startingPoint",
+        'postcode', c.postcode,
+        'latitude', c.latitude,
+        'longitude', c.longitude,
+        'description', c.description,
+        'pricingPlan', c."pricingPlan",
+        'isActive', c."isActive",
+        'createdAt', c."createdAt",
+        'updatedAt', c."updatedAt",
+    
+    -- Captain profile data
+        'captain', jsonb_build_object(
+            'id', cp.id,
+            'firstName', cp."firstName",
+            'lastName', cp."lastName",
+            'displayName', cp."displayName",
+            'phone', cp.phone,
+            'bio', cp.bio,
+            'experienceYrs', cp."experienceYrs",
+            'avatarUrl', cp."avatarUrl"
+        ),
+    
+    -- Boat data
+        'boat', CASE 
+            WHEN b.id IS NOT NULL THEN
+                jsonb_build_object(
+                    'id', b.id,
+                    'name', b."name",
+                    'type', b.type,
+                    'lengthFt', b."lengthFt",
+                    'capacity', b.capacity
+                )
+            ELSE NULL
+        END,
+    
+    -- Trips array
+        'trips', COALESCE(
+            (
+                SELECT jsonb_agg(
+                    jsonb_build_object(
+                        'id', t.id,
+                        'name', t."name",
+                        'tripType', t."tripType",
+                        'price', t.price,
+                        'durationHours', t."durationHours",
+                        'maxAnglers', t."maxAnglers",
+                        'style', t.style,
+                        'description', t.description,
+                        'promoPrice', t."promoPrice",
+                        'startTimes', (
+                            SELECT jsonb_agg(jsonb_build_object('value', tst.value))
+                            FROM "TripStartTime" tst
+                            WHERE tst."tripId" = t.id
+                        ),
+                        'species', (
+                            SELECT jsonb_agg(jsonb_build_object('value', ts.value))
+                            FROM "TripSpecies" ts
+                            WHERE ts."tripId" = t.id
+                        ),
+                        'techniques', (
+                            SELECT jsonb_agg(jsonb_build_object('value', tt.value))
+                            FROM "TripTechnique" tt
+                            WHERE tt."tripId" = t.id
+                        )
+                    )
+                )
+                FROM "Trip" t
+                WHERE t."charterId" = c.id
+            ),
+            '[]'::jsonb
+        ),
+    
+    -- Amenities array
+        'amenities', COALESCE(
+            (
+                SELECT jsonb_agg(jsonb_build_object('label', ca.label))
+                FROM "CharterAmenity" ca
+                WHERE ca."charterId" = c.id
+            ),
+            '[]'::jsonb
+        ),
+    
+    -- Features array
+        'features', COALESCE(
+            (
+                SELECT jsonb_agg(jsonb_build_object('label', cf.label))
+                FROM "CharterFeature" cf
+                WHERE cf."charterId" = c.id
+            ),
+            '[]'::jsonb
+        ),
+    
+    -- Media array (only charter-associated media)
+        'media', COALESCE(
+            (
+                SELECT jsonb_agg(
+                    jsonb_build_object(
+                        'url', cm.url,
+                        'storageKey', cm."storageKey",
+                        'sortOrder', cm."sortOrder",
+                        'mimeType', cm."mimeType",
+                        'kind', 'CHARTER_PHOTO'
+                    )
+                    ORDER BY cm."sortOrder"
+                )
+                FROM "CharterMedia" cm
+                WHERE cm."charterId" = c.id
+            ),
+            '[]'::jsonb
+        ),
+
+    -- Videos array (from CharterVideo junction table - uses proper many-to-many with ordering)
+        'videos', COALESCE(
+            (
+                SELECT jsonb_agg(
+                    jsonb_build_object(
+                        'url', COALESCE(cv."ready720pUrl", cv."originalUrl"),
+                        'name', COALESCE(cv."normalizedBlobKey", cv."blobKey"),
+                        'thumbnailUrl', cv."thumbnailUrl",
+                        'kind', 'CHARTER_VIDEO',
+                        'sortOrder', cvj."order"
+                    )
+                    ORDER BY cvj."order"
+                )
+                FROM "CharterVideo" cvj
+                INNER JOIN "CaptainVideo" cv ON cvj."videoId" = cv.id
+                WHERE cvj."charterId" = c.id
+            ),
+            '[]'::jsonb
+        ),
+    
+    -- Pickup data
+        'pickup', CASE 
+            WHEN p.id IS NOT NULL THEN
+                jsonb_build_object(
+                    'available', p.available,
+                    'fee', p.fee,
+                    'notes', p.notes,
+                    'areas', COALESCE(
+                        (
+                            SELECT jsonb_agg(jsonb_build_object('label', pa.label))
+                            FROM "PickupArea" pa
+                            WHERE pa."pickupId" = p.id
+                        ),
+                        '[]'::jsonb
+                    )
+                )
+            ELSE NULL
+        END,
+    
+    -- Policies data
+        'policies', CASE 
+            WHEN pol.id IS NOT NULL THEN
+                jsonb_build_object(
+                    'licenseProvided', pol."licenseProvided",
+                    'catchAndKeep', pol."catchAndKeep",
+                    'catchAndRelease', pol."catchAndRelease",
+                    'childFriendly', pol."childFriendly",
+                    'liveBaitProvided', pol."liveBaitProvided",
+                    'alcoholAllowed', NOT pol."alcoholNotAllowed",
+                    'smokingAllowed', NOT pol."smokingNotAllowed"
+                )
+            ELSE NULL
+        END,
+    
+    -- Schedule data (operational days)
+        'schedule', CASE 
+            WHEN cs.id IS NOT NULL THEN
+                jsonb_build_object(
+                    'type', cs."scheduleType",
+                    'operationalDays', cs."operationalDays"
+                )
+            ELSE NULL
+        END,
+    
+    -- Unavailability periods
+        'unavailability', COALESCE(
+            (
+                SELECT jsonb_agg(
+                    jsonb_build_object(
+                        'startDate', cu."startDate",
+                        'endDate', cu."endDate",
+                        'reason', cu.reason
+                    )
+                    ORDER BY cu."startDate"
+                )
+                FROM "charter_unavailability" cu
+                WHERE cu."charterId" = c.id
+            ),
+            '[]'::jsonb
+        )
+    ) AS charter
+
+FROM "Charter" c
+INNER JOIN "CaptainProfile" cp ON c."captainId" = cp.id
+LEFT JOIN "Boat" b ON c."boatId" = b.id
+LEFT JOIN "Pickup" p ON c.id = p."charterId"
+LEFT JOIN "Policies" pol ON c.id = pol."charterId"
+LEFT JOIN "charter_schedules" cs ON c.id = cs."charterId"
+WHERE c."isActive" = true;
+
+-- Ensure indexes for optimal query performance
+CREATE INDEX IF NOT EXISTS idx_charter_active ON "Charter"("isActive") WHERE "isActive" = true;
+CREATE INDEX IF NOT EXISTS idx_charter_video_charter_order ON "CharterVideo"("charterId", "order");
+CREATE INDEX IF NOT EXISTS idx_captain_video_status ON "CaptainVideo"("processStatus", "originalDeletedAt") WHERE "processStatus" = 'ready' AND "originalDeletedAt" IS NULL;

--- a/prisma/migrations/20251103171900_migrate_existing_videos_to_junction/migration.sql
+++ b/prisma/migrations/20251103171900_migrate_existing_videos_to_junction/migration.sql
@@ -1,0 +1,36 @@
+-- Migrate existing CaptainVideo relationships to CharterVideo junction table
+-- This script creates junction records for all videos that have charterId set
+
+-- STEP 1: Show what we're migrating
+DO $$
+BEGIN
+  RAISE NOTICE 'Videos to migrate:';
+  RAISE NOTICE 'Total CaptainVideo with charterId: %', (SELECT COUNT(*) FROM "CaptainVideo" WHERE "charterId" IS NOT NULL);
+  RAISE NOTICE 'Ready videos: %', (SELECT COUNT(*) FROM "CaptainVideo" WHERE "charterId" IS NOT NULL AND "processStatus" = 'ready');
+  RAISE NOTICE 'Non-deleted: %', (SELECT COUNT(*) FROM "CaptainVideo" WHERE "charterId" IS NOT NULL AND "originalDeletedAt" IS NULL);
+END $$;
+
+-- STEP 2: Insert junction records for existing video-charter relationships
+INSERT INTO "CharterVideo" ("charterId", "videoId", "order", "createdAt", "updatedAt")
+SELECT 
+  cv."charterId",
+  cv.id,
+  ROW_NUMBER() OVER (PARTITION BY cv."charterId" ORDER BY cv."createdAt") - 1 as "order",
+  NOW(),
+  NOW()
+FROM "CaptainVideo" cv
+WHERE cv."charterId" IS NOT NULL
+  AND cv."originalDeletedAt" IS NULL
+  -- REMOVED processStatus check - migrate all videos regardless of status
+  AND NOT EXISTS (
+    -- Skip if junction record already exists
+    SELECT 1 FROM "CharterVideo" cvj 
+    WHERE cvj."charterId" = cv."charterId" 
+    AND cvj."videoId" = cv.id
+  );
+
+-- STEP 3: Report migration results
+DO $$
+BEGIN
+  RAISE NOTICE 'Migration complete. Total CharterVideo records: %', (SELECT COUNT(*) FROM "CharterVideo");
+END $$;

--- a/src/app/api/public/charters/[id]/route.ts
+++ b/src/app/api/public/charters/[id]/route.ts
@@ -82,13 +82,15 @@ export async function GET(
     const { id } = await ctx.params;
 
     // Query the view for specific charter
-    const charters = await prisma.$queryRaw<PublicCharterView[]>`
+    const result = await prisma.$queryRaw<
+      Array<{ id: string; charter: PublicCharterView }>
+    >`
       SELECT * FROM v_public_charters
       WHERE id = ${id}
       LIMIT 1
     `;
 
-    if (charters.length === 0) {
+    if (result.length === 0) {
       return applySecurityHeaders(
         NextResponse.json(
           { error: "not_found", message: "Charter not found" },
@@ -97,16 +99,14 @@ export async function GET(
       );
     }
 
+    // The view returns { id, charter } where charter is the JSONB object
     return applySecurityHeaders(
-      NextResponse.json(
-        { charter: charters[0] },
-        {
-          status: 200,
-          headers: {
-            "Cache-Control": "public, s-maxage=300, stale-while-revalidate=600",
-          },
-        }
-      )
+      NextResponse.json(result[0].charter, {
+        status: 200,
+        headers: {
+          "Cache-Control": "public, s-maxage=300, stale-while-revalidate=600",
+        },
+      })
     );
   } catch (error) {
     console.error("Error fetching charter:", error);

--- a/src/app/api/videos/list/route.ts
+++ b/src/app/api/videos/list/route.ts
@@ -7,26 +7,14 @@ export async function GET(req: NextRequest) {
   const userId =
     searchParams.get("ownerId") || searchParams.get("userId") || undefined;
   const charterId = searchParams.get("charterId") || undefined;
-  const parsed = ListQuerySchema.safeParse({ ownerId: userId });
-  if (!parsed.success) {
-    return NextResponse.json({ error: "invalid_query" }, { status: 400 });
-  }
 
-  // Get captain profile ID from userId
-  if (!parsed.data.ownerId) {
-    return NextResponse.json({ error: "missing_user_id" }, { status: 400 });
-  }
-
-  const captainProfile = await prisma.captainProfile.findUnique({
-    where: { userId: parsed.data.ownerId },
-    select: { id: true },
+  console.log("[/api/videos/list] Request:", {
+    userId,
+    charterId,
+    url: req.url,
   });
 
-  if (!captainProfile) {
-    return NextResponse.json({ videos: [] });
-  }
-
-  // If charterId provided, filter using junction table
+  // If charterId provided, fetch directly from junction table (no ownerId needed)
   if (charterId) {
     const charterVideos = await prisma.charterVideo.findMany({
       where: { charterId: charterId },
@@ -42,14 +30,53 @@ export async function GET(req: NextRequest) {
       order: cv.order, // Include order for potential sorting UI
     }));
 
+    console.log("[/api/videos/list] Returning from CharterVideo junction:", {
+      charterId,
+      count: videos.length,
+      videoIds: videos.map((v) => v.id.substring(0, 8)),
+    });
+
     return NextResponse.json({ videos });
   }
 
-  // No charterId: return all captain's videos
+  // No charterId provided - need ownerId to fetch captain's unlinked videos
+  const parsed = ListQuerySchema.safeParse({ ownerId: userId });
+  if (!parsed.success) {
+    return NextResponse.json({ error: "invalid_query" }, { status: 400 });
+  }
+
+  if (!parsed.data.ownerId) {
+    return NextResponse.json({ error: "missing_user_id" }, { status: 400 });
+  }
+
+  const captainProfile = await prisma.captainProfile.findUnique({
+    where: { userId: parsed.data.ownerId },
+    select: { id: true },
+  });
+
+  if (!captainProfile) {
+    return NextResponse.json({ videos: [] });
+  }
+
+  // Return ONLY unlinked videos (videos not associated with any charter)
+  // This is for the gallery/video manager when selecting videos to link
   const videos = await prisma.captainVideo.findMany({
-    where: { captainId: captainProfile.id },
+    where: {
+      captainId: captainProfile.id,
+      // Only include videos that have NO CharterVideo junction records
+      charters: {
+        none: {},
+      },
+    },
     orderBy: { createdAt: "desc" },
     take: 25,
   });
+
+  console.log("[/api/videos/list] Returning unlinked videos (no charterId):", {
+    captainId: captainProfile.id,
+    count: videos.length,
+    videoIds: videos.map((v) => v.id.substring(0, 8)),
+  });
+
   return NextResponse.json({ videos });
 }

--- a/src/features/charter-onboarding/FormSection.tsx
+++ b/src/features/charter-onboarding/FormSection.tsx
@@ -880,6 +880,8 @@ export default function FormSection() {
                 (session?.user as { id?: string; role?: string } | undefined)
                   ?.id || ""
               }
+              charterId={currentCharterId}
+              draftId={serverDraftId}
             />
           )}
           {submitState?.type === "error" && (

--- a/src/features/charter-onboarding/steps/ReviewStep.tsx
+++ b/src/features/charter-onboarding/steps/ReviewStep.tsx
@@ -6,6 +6,8 @@ import { useEffect, useState } from "react";
 type ReviewStepProps = {
   charter: Charter;
   ownerId: string;
+  charterId?: string | null; // For edit mode: fetch from CharterVideo junction
+  draftId?: string | null; // For new charter: fetch from temp draft links
 };
 
 interface VideoRecord {
@@ -17,7 +19,12 @@ interface VideoRecord {
   processedDurationSec?: number | null;
 }
 
-export function ReviewStep({ charter, ownerId }: ReviewStepProps) {
+export function ReviewStep({
+  charter,
+  ownerId,
+  charterId,
+  draftId,
+}: ReviewStepProps) {
   const [videos, setVideos] = useState<
     { url: string; name?: string; thumbnailUrl?: string | null }[]
   >([]);
@@ -26,12 +33,76 @@ export function ReviewStep({ charter, ownerId }: ReviewStepProps) {
   useEffect(() => {
     const fetchVideos = async () => {
       try {
+        // Priority 1: Edit mode - fetch from CharterVideo junction by charterId
+        if (charterId) {
+          const res = await fetch(`/api/videos/list?charterId=${charterId}`);
+          if (res.ok) {
+            const data = await res.json();
+            const videoRecords: VideoRecord[] = data.videos || [];
+
+            const previewVideos = videoRecords
+              .filter((v) => v.processStatus === "ready")
+              .map((v, index) => ({
+                url: v.ready720pUrl || v.originalUrl,
+                name: `video-${index + 1}`,
+                thumbnailUrl: v.thumbnailUrl,
+                durationSeconds: v.processedDurationSec ?? undefined,
+              }))
+              .filter((v) => !!v.url);
+
+            console.log(
+              "[ReviewStep] Fetched videos for charter (edit mode):",
+              {
+                charterId,
+                total: videoRecords.length,
+                ready: previewVideos.length,
+              }
+            );
+
+            setVideos(previewVideos);
+            setLoading(false);
+            return;
+          }
+        }
+
+        // Priority 2: New charter with draft - fetch from CharterVideo junction by draftId
+        if (draftId) {
+          const res = await fetch(`/api/videos/list?charterId=${draftId}`);
+          if (res.ok) {
+            const data = await res.json();
+            const videoRecords: VideoRecord[] = data.videos || [];
+
+            const previewVideos = videoRecords
+              .filter((v) => v.processStatus === "ready")
+              .map((v, index) => ({
+                url: v.ready720pUrl || v.originalUrl,
+                name: `video-${index + 1}`,
+                thumbnailUrl: v.thumbnailUrl,
+                durationSeconds: v.processedDurationSec ?? undefined,
+              }))
+              .filter((v) => !!v.url);
+
+            console.log(
+              "[ReviewStep] Fetched videos for draft (new charter mode):",
+              {
+                draftId,
+                total: videoRecords.length,
+                ready: previewVideos.length,
+              }
+            );
+
+            setVideos(previewVideos);
+            setLoading(false);
+            return;
+          }
+        }
+
+        // Priority 3: Fallback - fetch all captain's videos (legacy behavior)
         const res = await fetch(`/api/videos/list?ownerId=${ownerId}`);
         if (res.ok) {
           const data = await res.json();
           const videoRecords: VideoRecord[] = data.videos || [];
 
-          // Transform to preview format, only include ready videos
           const previewVideos = videoRecords
             .filter((v) => v.processStatus === "ready")
             .map((v, index) => ({
@@ -42,10 +113,9 @@ export function ReviewStep({ charter, ownerId }: ReviewStepProps) {
             }))
             .filter((v) => !!v.url);
 
-          console.log("[ReviewStep] Fetched videos:", {
+          console.log("[ReviewStep] Fetched all captain videos (fallback):", {
             total: videoRecords.length,
             ready: previewVideos.length,
-            sample: previewVideos[0],
           });
 
           setVideos(previewVideos);
@@ -58,7 +128,7 @@ export function ReviewStep({ charter, ownerId }: ReviewStepProps) {
     };
 
     fetchVideos();
-  }, [ownerId]);
+  }, [ownerId, charterId, draftId]);
 
   if (loading) {
     return (


### PR DESCRIPTION
This pull request implements a comprehensive migration of charter video relationships to a new, normalized many-to-many structure using a `CharterVideo` junction table. It updates the public charters view, migrates existing data, and refactors both backend API logic and frontend components to use the new structure for fetching and displaying charter videos. The changes ensure that videos are properly associated with charters (including ordering), and that both edit and onboarding flows work seamlessly with the new model.

**Database migration and data model normalization:**

* Updated the `v_public_charters` database view to use the `CharterVideo` junction table instead of a direct foreign key from `CaptainVideo`, enabling a proper many-to-many relationship with ordering for charter videos. Added indexes to optimize queries.
* Added a migration script to backfill the `CharterVideo` junction table for all existing `CaptainVideo` records with a `charterId`, ensuring no data loss during the transition.

**Backend API updates:**

* Refactored the `/api/videos/list` endpoint to fetch videos via the `CharterVideo` junction table when a `charterId` is provided, and to only return unlinked videos (not associated with any charter) when listing by owner. Improved logging for debugging. [[1]](diffhunk://#diff-c4843be12f76d2a3a9f8c00d0a4991015f062a1bbac405835d135e185281595dL10-R17) [[2]](diffhunk://#diff-c4843be12f76d2a3a9f8c00d0a4991015f062a1bbac405835d135e185281595dR33-R80)
* Updated the `/api/public/charters/[id]` endpoint to match the new view output, returning the `charter` JSON object directly from the view. ([src/app/api/public/charters/[id]/route.tsL85-R93](diffhunk://#diff-face63dcd7d9877d44acf5197ed18e72177c36e71b0b5ee4e4e4c8436ed5c461L85-R93), [src/app/api/public/charters/[id]/route.tsR102-R109](diffhunk://#diff-face63dcd7d9877d44acf5197ed18e72177c36e71b0b5ee4e4e4c8436ed5c461R102-R109))

**Frontend onboarding and review improvements:**

* Enhanced the charter onboarding `ReviewStep` component to prioritize fetching charter videos from the `CharterVideo` junction table (by `charterId` for edit mode or `draftId` for new charters), falling back to the captain's unlinked videos only if necessary. Improved logging for clarity. [[1]](diffhunk://#diff-60e23ae12ef9773895439602c11be23eb608f1a08862b60928003090f7d915f2R9-R10) [[2]](diffhunk://#diff-60e23ae12ef9773895439602c11be23eb608f1a08862b60928003090f7d915f2L20-R27) [[3]](diffhunk://#diff-60e23ae12ef9773895439602c11be23eb608f1a08862b60928003090f7d915f2R36-L34) [[4]](diffhunk://#diff-60e23ae12ef9773895439602c11be23eb608f1a08862b60928003090f7d915f2L45-L48) [[5]](diffhunk://#diff-60e23ae12ef9773895439602c11be23eb608f1a08862b60928003090f7d915f2L61-R131)
* Passed `charterId` and `draftId` props from the onboarding form to the `ReviewStep` to enable the new video-fetching logic.

These changes together ensure a robust, normalized, and future-proof handling of charter videos throughout the stack.