### PR TITLE
feat: Add HEIC to JPEG conversion for image uploads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "date-fns": "^4.1.0",
         "ffmpeg-static": "^5.2.0",
         "fluent-ffmpeg": "^2.1.3",
+        "heic-convert": "^2.1.0",
         "lucide-react": "^0.544.0",
         "mp4box": "^0.5.4",
         "next": "15.5.3",
@@ -10341,6 +10342,41 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/heic-convert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/heic-convert/-/heic-convert-2.1.0.tgz",
+      "integrity": "sha512-1qDuRvEHifTVAj3pFIgkqGgJIr0M3X7cxEPjEp0oG4mo8GFjq99DpCo8Eg3kg17Cy0MTjxpFdoBHOatj7ZVKtg==",
+      "license": "ISC",
+      "dependencies": {
+        "heic-decode": "^2.0.0",
+        "jpeg-js": "^0.4.4",
+        "pngjs": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/heic-convert/node_modules/pngjs": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/heic-decode": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/heic-decode/-/heic-decode-2.1.0.tgz",
+      "integrity": "sha512-0fB3O3WMk38+PScbHLVp66jcNhsZ/ErtQ6u2lMYu/YxXgbBtl+oKOhGQHa4RpvE68k8IzbWkABzHnyAIjR758A==",
+      "license": "ISC",
+      "dependencies": {
+        "libheif-js": "^1.19.8"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -11054,6 +11090,12 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -11275,6 +11317,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/libheif-js": {
+      "version": "1.19.8",
+      "resolved": "https://registry.npmjs.org/libheif-js/-/libheif-js-1.19.8.tgz",
+      "integrity": "sha512-vQJWusIxO7wavpON1dusciL8Go9jsIQ+EUrckauFYAiSTjcmLAsuJh3SszLpvkwPci3JcL41ek2n+LUZGFpPIQ==",
+      "license": "LGPL-3.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/lightningcss": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "date-fns": "^4.1.0",
     "ffmpeg-static": "^5.2.0",
     "fluent-ffmpeg": "^2.1.3",
+    "heic-convert": "^2.1.0",
     "lucide-react": "^0.544.0",
     "mp4box": "^0.5.4",
     "next": "15.5.3",

--- a/src/app/api/blob/upload/route.ts
+++ b/src/app/api/blob/upload/route.ts
@@ -1,6 +1,7 @@
 // app/api/blob/upload/route.ts
 import { MAX_SHORT_VIDEO_BYTES } from "@/config/mediaProcessing";
 import authOptions from "@/lib/auth";
+import { processImageFile } from "@/lib/heicConverter";
 import { counter } from "@/lib/metrics";
 import { prisma } from "@/lib/prisma";
 import { put } from "@vercel/blob";
@@ -47,6 +48,15 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Missing file" }, { status: 400 });
     }
 
+    // Convert HEIC to JPEG if it's an image file
+    let processedFile = file;
+    const isImage =
+      file.type.startsWith("image/") ||
+      /\.(jpe?g|png|gif|webp|avif|heic|heif|bmp)$/i.test(file.name);
+    if (isImage) {
+      processedFile = await processImageFile(file, 0.92);
+    }
+
     // Sanitize and normalize docType
     const allowed = new Set([
       "idFront",
@@ -64,7 +74,7 @@ export async function POST(req: Request) {
         : "unknown";
 
     // Sanitize filename for blob storage (preserve original name)
-    const originalName = file.name || "file";
+    const originalName = processedFile.name || "file";
     const sanitized = originalName.replace(/[^\w\d.-]/g, "_").slice(0, 200);
     const timestamp = Date.now();
     const charterId = typeof charterIdRaw === "string" ? charterIdRaw : null;
@@ -138,7 +148,7 @@ export async function POST(req: Request) {
       );
     }
 
-    const { url } = await put(key, file, {
+    const { url } = await put(key, processedFile, {
       access: "public",
       token: process.env.BLOB_READ_WRITE_TOKEN,
       addRandomSuffix: false,
@@ -174,12 +184,17 @@ export async function POST(req: Request) {
           where: { userId },
           select: { id: true },
         });
-        
+
         if (!captainProfile) {
-          console.error(`[blob-upload] No CaptainProfile found for user ${userId}`);
-          return NextResponse.json({ error: "captain_profile_not_found" }, { status: 404 });
+          console.error(
+            `[blob-upload] No CaptainProfile found for user ${userId}`
+          );
+          return NextResponse.json(
+            { error: "captain_profile_not_found" },
+            { status: 404 }
+          );
         }
-        
+
         const captainVideo = await prisma.captainVideo.create({
           data: {
             captainId: captainProfile.id,
@@ -284,8 +299,8 @@ export async function POST(req: Request) {
           charterId: tempCharterId,
           url,
           storageKey: key,
-          mimeType: file.type,
-          sizeBytes: file.size,
+          mimeType: processedFile.type,
+          sizeBytes: processedFile.size,
           sortOrder: 0, // Will be reordered on finalize
         },
       });

--- a/src/app/api/media/photo/route.ts
+++ b/src/app/api/media/photo/route.ts
@@ -1,4 +1,5 @@
 import authOptions from "@/lib/auth";
+import { processImageFile } from "@/lib/heicConverter";
 import { prisma } from "@/lib/prisma";
 import { put } from "@vercel/blob";
 import { getServerSession } from "next-auth";
@@ -36,11 +37,15 @@ export async function POST(req: Request) {
     if (!file.type.startsWith("image/")) {
       return NextResponse.json({ error: "not_image" }, { status: 400 });
     }
-    const originalName = file.name || "photo";
+
+    // Convert HEIC to JPEG if needed
+    const processedFile = await processImageFile(file, 0.92);
+
+    const originalName = processedFile.name || "photo";
     const sanitized = originalName.replace(/[^\w\d.-]/g, "_").slice(0, 160);
     const ts = Date.now();
     const storageKey = `captains/${userId}/media/${ts}-${sanitized}`;
-    const putRes = await put(storageKey, file, {
+    const putRes = await put(storageKey, processedFile, {
       access: "public",
       token: process.env.BLOB_READ_WRITE_TOKEN,
       addRandomSuffix: false,
@@ -87,8 +92,8 @@ export async function POST(req: Request) {
         charterId: charterIdFinal, // will be null if no real charter
         url: putRes.url,
         storageKey,
-        mimeType: file.type,
-        sizeBytes: file.size,
+        mimeType: processedFile.type,
+        sizeBytes: processedFile.size,
         sortOrder: nextOrder,
       },
       select: { id: true },

--- a/src/lib/__tests__/heicConverter.test.ts
+++ b/src/lib/__tests__/heicConverter.test.ts
@@ -1,0 +1,56 @@
+/**
+ * HEIC Converter Test
+ * Simple test to verify HEIC detection and conversion logic
+ */
+
+import { describe, expect, it } from "vitest";
+import { isHeicFile } from "../heicConverter";
+
+describe("heicConverter", () => {
+  describe("isHeicFile", () => {
+    it("should detect HEIC files by extension", () => {
+      const file = new File(["test"], "photo.heic", { type: "image/jpeg" });
+      expect(isHeicFile(file)).toBe(true);
+    });
+
+    it("should detect HEIF files by extension", () => {
+      const file = new File(["test"], "photo.heif", { type: "image/jpeg" });
+      expect(isHeicFile(file)).toBe(true);
+    });
+
+    it("should detect HEIC files by MIME type", () => {
+      const file = new File(["test"], "photo.jpg", { type: "image/heic" });
+      expect(isHeicFile(file)).toBe(true);
+    });
+
+    it("should detect HEIF files by MIME type", () => {
+      const file = new File(["test"], "photo.jpg", { type: "image/heif" });
+      expect(isHeicFile(file)).toBe(true);
+    });
+
+    it("should handle uppercase extensions", () => {
+      const file = new File(["test"], "photo.HEIC", { type: "image/jpeg" });
+      expect(isHeicFile(file)).toBe(true);
+    });
+
+    it("should handle uppercase MIME types", () => {
+      const file = new File(["test"], "photo.jpg", { type: "IMAGE/HEIC" });
+      expect(isHeicFile(file)).toBe(true);
+    });
+
+    it("should not detect regular JPEG files", () => {
+      const file = new File(["test"], "photo.jpg", { type: "image/jpeg" });
+      expect(isHeicFile(file)).toBe(false);
+    });
+
+    it("should not detect PNG files", () => {
+      const file = new File(["test"], "photo.png", { type: "image/png" });
+      expect(isHeicFile(file)).toBe(false);
+    });
+
+    it("should not detect WebP files", () => {
+      const file = new File(["test"], "photo.webp", { type: "image/webp" });
+      expect(isHeicFile(file)).toBe(false);
+    });
+  });
+});

--- a/src/lib/heicConverter.ts
+++ b/src/lib/heicConverter.ts
@@ -1,0 +1,96 @@
+/**
+ * HEIC to JPEG Conversion Utility
+ * Converts HEIC/HEIF images to JPEG format for web compatibility
+ */
+
+import convert from "heic-convert";
+
+/**
+ * Check if a file is HEIC/HEIF format
+ */
+export function isHeicFile(file: File): boolean {
+  const name = file.name.toLowerCase();
+  const type = file.type.toLowerCase();
+
+  return (
+    name.endsWith(".heic") ||
+    name.endsWith(".heif") ||
+    type === "image/heic" ||
+    type === "image/heif"
+  );
+}
+
+/**
+ * Convert HEIC file to JPEG
+ * @param file - HEIC file to convert
+ * @param quality - JPEG quality (0-1), default 0.92
+ * @returns Converted File object in JPEG format
+ */
+export async function convertHeicToJpeg(
+  file: File,
+  quality: number = 0.92
+): Promise<File> {
+  try {
+    // Read file as ArrayBuffer
+    const arrayBuffer = await file.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+
+    // Convert HEIC to JPEG
+    const outputBuffer = await convert({
+      buffer,
+      format: "JPEG",
+      quality, // 0-1 scale
+    });
+
+    // Create new File object with JPEG data
+    // Convert Buffer to Uint8Array for Blob compatibility
+    const uint8Array = new Uint8Array(outputBuffer);
+    const jpegBlob = new Blob([uint8Array], { type: "image/jpeg" });
+
+    // Generate new filename: replace .heic/.heif with .jpg
+    const originalName = file.name.replace(/\.(heic|heif)$/i, ".jpg");
+    const jpegFile = new File([jpegBlob], originalName, {
+      type: "image/jpeg",
+      lastModified: Date.now(),
+    });
+
+    console.log(
+      `[heic-convert] Converted ${file.name} (${formatBytes(file.size)}) to ${jpegFile.name} (${formatBytes(jpegFile.size)})`
+    );
+
+    return jpegFile;
+  } catch (error) {
+    console.error("[heic-convert] Conversion failed:", error);
+    throw new Error(
+      `Failed to convert HEIC image: ${error instanceof Error ? error.message : "Unknown error"}`
+    );
+  }
+}
+
+/**
+ * Process file - convert if HEIC, otherwise return as-is
+ * @param file - File to process
+ * @param quality - JPEG quality if conversion needed (0-1), default 0.92
+ * @returns Original file or converted JPEG file
+ */
+export async function processImageFile(
+  file: File,
+  quality: number = 0.92
+): Promise<File> {
+  if (isHeicFile(file)) {
+    console.log(`[heic-convert] Detected HEIC file: ${file.name}`);
+    return await convertHeicToJpeg(file, quality);
+  }
+  return file;
+}
+
+/**
+ * Format bytes to human-readable string
+ */
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 Bytes";
+  const k = 1024;
+  const sizes = ["Bytes", "KB", "MB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${Math.round((bytes / Math.pow(k, i)) * 100) / 100} ${sizes[i]}`;
+}

--- a/src/types/heic-convert.d.ts
+++ b/src/types/heic-convert.d.ts
@@ -1,0 +1,11 @@
+declare module "heic-convert" {
+  interface ConvertOptions {
+    buffer: Buffer;
+    format: "JPEG" | "PNG";
+    quality: number; // 0-1 for JPEG
+  }
+
+  function convert(options: ConvertOptions): Promise<Buffer>;
+
+  export default convert;
+}


### PR DESCRIPTION
- Install heic-convert library for server-side image conversion
- Create heicConverter utility with detection and conversion logic
- Add TypeScript type definitions for heic-convert module
- Update /api/blob/upload to convert HEIC images before upload
- Update /api/media/photo to convert HEIC images before storage
- Add unit tests for HEIC file detection
- Set JPEG quality to 92% for optimal size/quality balance
- Log conversion events for monitoring

Fixes: HEIC images not loading in browsers (Chrome, Firefox, Edge) All HEIC/HEIF uploads are now automatically converted to JPEG